### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/plugins/3-premetadata-plugins/transcribe_plugin/functions/app.js
+++ b/plugins/3-premetadata-plugins/transcribe_plugin/functions/app.js
@@ -8,6 +8,18 @@ exports.lambdaHandler = async (event) => {
   console.log(JSON.stringify(event, null, 4));
 
   const cloudFrontUrl = event.detail.video.playbackUrl;
+  // Validate the playBackUrl to prevent SSRF attacks
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(cloudFrontUrl);
+  } catch (err) {
+    throw new Error('Invalid CloudFront URL');
+  }
+  // Allow only CloudFront domains. You can update this allowlist as needed for your environment.
+  const allowedHostSuffix = '.cloudfront.net';
+  if (!parsedUrl.hostname.endsWith(allowedHostSuffix)) {
+    throw new Error('CloudFront URL is not allowed.');
+  }
   // Split the string using the delimiter '/'
   const urlParts = cloudFrontUrl.split('/ivs');
   // Get the last item (which is the object key)


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-video/security/code-scanning/2](https://github.com/aws-samples/serverless-video/security/code-scanning/2)

To mitigate SSRF, we must restrict which URLs can be requested. For this scenario, we should ensure that `cloudFrontUrl` always points to an expected CloudFront distribution or a set of known domains. The best way is to parse the URL and check that its hostname matches an allow-list (for example, only domains ending with `.cloudfront.net`). If the URL does not match the allowed domains, abort the request and return an error. This change must be made in the block preceding the request on line 18.

Required edits:
- Add URL validation before performing the `axios.get`.
- For Node.js, use the standard `URL` class to parse and inspect the hostname.
- Define an allow-list of permitted hostnames (e.g., allow only CloudFront domains).
- If the hostname check fails, throw an error or return a 400 response.
- No new external libraries are required, as Node.js provides `URL`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
