### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/plugins/1-prevalidate-plugins/content_moderation_plugin/functions/downloader.js
+++ b/plugins/1-prevalidate-plugins/content_moderation_plugin/functions/downloader.js
@@ -1,6 +1,12 @@
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const axios = require('axios');
 
+// Define allow-list of trusted CloudFront hostnames (use actual distribution domains you control)
+const ALLOWED_CLOUDFRONT_HOSTNAMES = [
+  "YOUR_DISTRIBUTION.cloudfront.net",
+  // You can add more trusted hostnames here
+];
+
 const destinationBucketName = process.env.BucketName;
 const s3 = new S3Client({ region: process.env.AWS_REGION });
 
@@ -10,13 +16,8 @@ function isValidCloudFrontUrl(urlString) {
     const url = new URL(urlString);
     // Only allow HTTPS
     if (url.protocol !== "https:") return false;
-    // Only allow trusted CloudFront domain(s)
-    // Replace the domain as needed for your setup.
-    // Example: pattern matches standard CloudFront, or specific domain (safer!)
-    // const allowedDomain = "YOUR_DISTRIBUTION.cloudfront.net";
-    // return url.hostname === allowedDomain;
-    // Or allow any .cloudfront.net domain (less strict)
-    if (!url.hostname.endsWith(".cloudfront.net")) return false;
+    // Only allow trusted CloudFront distribution domains
+    if (!ALLOWED_CLOUDFRONT_HOSTNAMES.includes(url.hostname)) return false;
     // Optionally, validate path or other properties
     return true;
   } catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-video/security/code-scanning/1](https://github.com/aws-samples/serverless-video/security/code-scanning/1)

To fix this SSRF vulnerability, you should restrict the outgoing HTTP requests so that only URLs associated with explicitly allowed (trusted) CloudFront distributions can be requested. The best approach is to maintain an allow-list of permitted CloudFront domains (or distribution IDs), and check the hostname of the incoming URL against this list inside `isValidCloudFrontUrl()`. Only if the hostname matches a known good value should the request proceed.  
Specifically, update `isValidCloudFrontUrl` to check if the hostname matches an entry in `ALLOWED_CLOUDFRONT_HOSTNAMES` array. Make sure to declare this array near the top, and fail invalid URLs (i.e., not in the allow-list).  
You only need to update `plugins/1-prevalidate-plugins/content_moderation_plugin/functions/downloader.js`. Add the array, update `isValidCloudFrontUrl`, and do not touch any other business logic or S3 handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
